### PR TITLE
Fix LAND_transfer_provinces "Unknown trigger type: list" (breaks all land transfers)

### DIFF
--- a/common/scripted_effects/se_LAND.txt
+++ b/common/scripted_effects/se_LAND.txt
@@ -368,57 +368,66 @@ LAND_transfer_provinces = {
 
 	# Remove foreign influence from state and relevant countries, if an entire state would be given away
 	# Otherwise, recalculate state influence % rating after all the provinces have been transferred
-	if = {
+	# [#348 diplo_play_fix] REMOVED a broken guard here. The block below (recalculate / strip foreign
+	# influence on transferred states) was wrapped in `if = { limit = { any_in_list = { list =
+	# $target_provinces$  state = { has_variable = DIPLOMACY_influenced_by } } } ... }`. That guard was
+	# added in the recent upstream refactor 554d8875 ("Refactored add and remove state influence, also
+	# accounting for land transfer") and shipped BROKEN: the any_in_list TRIGGER does not accept a
+	# MACRO-substituted `list = $target_provinces$` (Clausewitz resolves trigger list-args at parse
+	# time, before macro expansion) -> "Unknown trigger type: list" x38, one per call site, breaking
+	# EVERY land transfer (all diplo-play resolutions, AI peace deals, Qing subject absorption).
+	# PROVEN: no any_in_list+macro form works anywhere in the repo or the Invictus oracle; the sibling
+	# every_in_list = { list = $target_provinces$ } (used just below + at the transfer loops further
+	# down) takes the SAME macro fine, because effect-iterators resolve their list at runtime.
+	#
+	# FIX = drop the guard, run the body UNCONDITIONALLY. Behaviour-IDENTICAL: the guard was a pure
+	# short-circuit and the body is already self-limiting -- the first every_in_list filters on
+	# state.has_variable = DIPLOMACY_influenced_by (adds nothing when no province is influenced), the
+	# second iterates states_to_recalculate_influence (a no-op while that list stays empty), and the
+	# final recalc loop further down likewise no-ops on the empty list. With no influenced province the
+	# body does nothing (exactly what the guard produced); with influenced provinces it does the same
+	# work the guarded body did. No LOG marker (core hot path). See [[imp19c-proven-code-rule]].
+	every_in_list = {
+		list = $target_provinces$
 		limit = {
-			any_in_list = {
-				list = $target_provinces$
-				state = {
-					has_variable = DIPLOMACY_influenced_by
-				}
-			}
-		}
-		every_in_list = {
-			list = $target_provinces$
-			limit = {
-				state = {
-					has_variable = DIPLOMACY_influenced_by
-				}
-			}
 			state = {
-				if = {
-					limit = {
-						NOT = {
-							is_in_list = {
-								list = states_to_recalculate_influence
-							}
-						}
-					}
-					add_to_list = states_to_recalculate_influence
-				}
+				has_variable = DIPLOMACY_influenced_by
 			}
 		}
-		every_in_list = {
-			list = states_to_recalculate_influence
-			set_local_variable = {
-				name = state_transfer_provinces
-				value = {
-					value = 0
-					every_state_province = {
-						limit = {
-							is_in_list = $target_provinces$
-						}
-						add = 1
-					}
-				}
-			}
-			# If the entire state is to be traded away, then remove foreign influence
+		state = {
 			if = {
 				limit = {
-					local_var:state_transfer_provinces = FUNC_num_provinces_in_state
+					NOT = {
+						is_in_list = {
+							list = states_to_recalculate_influence
+						}
+					}
 				}
-				DIPLOMACY_remove_state_foreign_influence = yes
-				remove_from_list = states_to_recalculate_influence
+				add_to_list = states_to_recalculate_influence
 			}
+		}
+	}
+	every_in_list = {
+		list = states_to_recalculate_influence
+		set_local_variable = {
+			name = state_transfer_provinces
+			value = {
+				value = 0
+				every_state_province = {
+					limit = {
+						is_in_list = $target_provinces$
+					}
+					add = 1
+				}
+			}
+		}
+		# If the entire state is to be traded away, then remove foreign influence
+		if = {
+			limit = {
+				local_var:state_transfer_provinces = FUNC_num_provinces_in_state
+			}
+			DIPLOMACY_remove_state_foreign_influence = yes
+			remove_from_list = states_to_recalculate_influence
 		}
 	}
 


### PR DESCRIPTION
## Summary

`LAND_transfer_provinces` (`common/scripted_effects/se_LAND.txt`) fails to compile at load with **`Unknown trigger type: list`**, one error per call site. Because this effect is the shared path for moving province ownership, the failure makes **all land transfers silently do nothing** at runtime.

## The bug

In `LAND_transfer_provinces`, the foreign-influence recalculation block is wrapped in this guard (line numbers as on current `master`, `se_LAND.txt`):

```
371  if = {
372      limit = {
373          any_in_list = {
374              list = $target_provinces$
375              state = {
376                  has_variable = DIPLOMACY_influenced_by
377              }
378          }
379      }
380      every_in_list = { list = $target_provinces$  ... }   # recalc / strip influence
...
423  }
```

The problem is **`any_in_list` used as a TRIGGER (inside `limit = {}`) with a macro-substituted `list = $target_provinces$`** (lines 373–374).

The engine resolves a trigger's block arguments at **parse time**, *before* macro (`$...$`) expansion runs. At load, `$target_provinces$` has not yet been substituted, so the parser sees a bare `list` key it does not recognise as a valid trigger — hence `Unknown trigger type: list`.

This is specific to the **block form of a trigger**. The same macro works fine in the surrounding code:
- `every_in_list = { list = $target_provinces$ }` (an **effect iterator**, e.g. the very next block at line 380 and the transfer loops lower in the effect) — resolves its list at **runtime**, after expansion.
- `is_in_list = $target_provinces$` (the **bare shorthand**, no `list =` keyword, inside `every_state_province`'s `limit`) — also fine.

There is no working `any_in_list = { list = $macro$ }` in the file, because the pattern cannot work.

## Impact

`LAND_transfer_provinces` is the sanctioned way to move province ownership (it handles the governorship-wealth split internally), so the compile failure breaks every caller of it:

- `se_LAND.txt` → `LAND_release_from_list` (line 731) — the release-provinces-to-a-list path
- `se_AI.txt` → `AI_make_peace_province_wishlist` (line 2328) — AI peace-deal province transfers
- `se_AI.txt` → `AI_debug_restitute_land` (line 2472)
- `WAR_scripted_guis.txt` → `send_final_offer_button` (line 1199) — war final-offer resolution
- `events/imp19c_mod_events/diplomatic_play/agadir_crisis_type.txt` (lines 542, 554) — the Agadir crisis chain
- `events/DEBUG/debug_land.txt` — the debug transfer harness

Net effect: no province ownership changes via any of these paths.

## The fix

Remove the broken `if { limit { any_in_list … } }` guard and run its body **unconditionally**.

This is **behaviour-identical**, because the guard was a pure short-circuit over a body that is already self-limiting:

- The body's first `every_in_list` loops over `$target_provinces$` with `limit = { state = { has_variable = DIPLOMACY_influenced_by } }` — so when no province is influenced it does zero iterations and adds nothing to `states_to_recalculate_influence`.
- The second `every_in_list` loops over that (empty) list — a no-op — and is independently guarded by its inner `if local_var:state_transfer_provinces = FUNC_num_provinces_in_state`, so it does nothing for any state not fully in the current target set (safe even against a dirty list).

So "guard short-circuits" and "guard removed, body filters to nothing" produce identical state; when provinces *are* influenced, the body does exactly the work the guarded version did. The guard's `any_in_list` condition was precisely the condition under which the body does any work, which is why dropping it is safe rather than a behavioural change.

The fix uses only proven constructs (`every_in_list` + macro), touches nothing else, and preserves the file's original CRLF line endings so the diff is minimal.
